### PR TITLE
Fix the "-c" argument

### DIFF
--- a/vmmake
+++ b/vmmake
@@ -125,7 +125,7 @@ KERNCONFIG=
 NUMFILES=
 MKSRC=0
 NONET=0
-while getopts a:cf:i:kp:s:t:x o; do
+while getopts a:c:f:i:kp:s:t:x o; do
     case "$o" in
     a)
         ARCH=$OPTARG


### PR DESCRIPTION
In the previous pull request, I'd missed the : on the "-c" argument, so the KERNCONFIG could never be set.